### PR TITLE
Use environment variable for YouTube API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Scraping_niche_youtube_automation
+# Scraping niche YouTube automation
+
+## Configuration
+
+Set the YouTube Data API key as an environment variable before running the scraper:
+
+```bash
+export YOUTUBE_API_KEY="your-api-key"
+python scraper
+```
+
+The scraper will read the `YOUTUBE_API_KEY` variable at startup and exit with an error if it is not provided.

--- a/scraper
+++ b/scraper
@@ -22,13 +22,19 @@ Langage : Python
 Librairies : googleapiclient (YouTube Data API v3), pandas, datetime, csv
 """
 
+import os
 import pandas as pd
 from googleapiclient.discovery import build
 from datetime import datetime
 import time
 
 # ---- CONFIGURATION ---- #
-API_KEY = "AIzaSyB4EyJbSIah4NRYv3FMqAE4wFrAnhQZpZ4"  # ← Replace with your actual YouTube Data API v3 key
+API_KEY = os.environ.get("YOUTUBE_API_KEY")
+if not API_KEY:
+    raise RuntimeError(
+        "The YOUTUBE_API_KEY environment variable must be set with a valid "
+        "YouTube Data API v3 key."
+    )
 SEARCH_KEYWORDS = ["self improvement", "AI tools", "wealth mindset", "luxury lifestyle", "crypto news"]
 MAX_RESULTS = 10  # per keyword
 OUTPUT_FILE = "youtube_channels_filtered.csv"


### PR DESCRIPTION
## Summary
- load the YouTube Data API key from the YOUTUBE_API_KEY environment variable with an explicit error when missing
- document how to provide the API key via environment variable in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e19aecb03c8325a039839b579f4f62