### PR TITLE
Adjust playlist pagination to honor max results

### DIFF
--- a/scraper
+++ b/scraper
@@ -69,18 +69,24 @@ def get_playlist_videos(playlist_id, max_results=50):
     next_page_token = None
 
     while True:
+        page_size = min(50, max_results - len(video_data))
+        if page_size <= 0:
+            break
         request = youtube.playlistItems().list(
             part="snippet,contentDetails",
             playlistId=playlist_id,
-            maxResults=50,
+            maxResults=page_size,
             pageToken=next_page_token
         )
         response = request.execute()
 
         video_data.extend(response['items'])
 
+        if len(video_data) >= max_results:
+            break
+
         next_page_token = response.get('nextPageToken')
-        if not next_page_token or len(video_data) >= max_results:
+        if not next_page_token:
             break
 
     return video_data


### PR DESCRIPTION
## Summary
- compute a page size before each playlistItems request that respects the remaining max results limit
- use the dynamic page size when fetching playlist videos and stop iterating once the max result count is reached

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19c52295c83258355a67fda2b1232